### PR TITLE
Replace cdn URLs

### DIFF
--- a/example/express-typescript/views/index.hbs
+++ b/example/express-typescript/views/index.hbs
@@ -25,7 +25,7 @@
             // Text that will be displayed on the left side under the logo. Text is limited to 100 characters, and rest will be truncated.
             text: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean mavdvd",
             // Logo URL that will be shown below the modal form.
-            logoUrl: 'https://cdn.nordigen.com/ais/Nordigen_Logo_Black.svg',
+            logoUrl: 'https://cdn-logos.gocardless.com/ais/Nordigen_Logo_Black.svg',
             // Will display country list with corresponding institutions. When `countryFilter` is set to `false`, only list of institutions will be shown.
             countryFilter: false,
             // style configs

--- a/example/express-user-app/views/index.hbs
+++ b/example/express-user-app/views/index.hbs
@@ -26,7 +26,7 @@
             // Text that will be displayed on the left side under the logo. Text is limited to 100 characters, and rest will be truncated.
             text: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean mavdvd",
             // Logo URL that will be shown below the modal form.
-            logoUrl: 'https://cdn.nordigen.com/ais/Nordigen_Logo_Black.svg',
+            logoUrl: 'https://cdn-logos.gocardless.com/ais/Nordigen_Logo_Black.svg',
             // Will display country list with corresponding institutions. When `countryFilter` is set to `false`, only list of institutions will be shown.
             countryFilter: true,
             // style configs

--- a/example/express-user-app/views/partials/nav.hbs
+++ b/example/express-user-app/views/partials/nav.hbs
@@ -2,7 +2,7 @@
     <div class='container'>
         <a class='navbar-brand' href='/'>
             <img
-                src='https://cdn.nordigen.com/ais/Nordigen_Logo_Black.svg'
+                src='https://cdn-logos.gocardless.com/ais/Nordigen_Logo_Black.svg'
                 width='120'
                 height='50'
                 class='d-inline-block align-text-top'

--- a/example/express/views/index.hbs
+++ b/example/express/views/index.hbs
@@ -25,7 +25,7 @@
             // Text that will be displayed on the left side under the logo. Text is limited to 100 characters, and rest will be truncated.
             text: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean mavdvd",
             // Logo URL that will be shown below the modal form.
-            logoUrl: 'https://cdn.nordigen.com/ais/Nordigen_Logo_Black.svg',
+            logoUrl: 'https://cdn-logos.gocardless.com/ais/Nordigen_Logo_Black.svg',
             // Will display country list with corresponding institutions. When `countryFilter` is set to `false`, only list of institutions will be shown.
             countryFilter: true,
             // style configs


### PR DESCRIPTION
Updated `cdn.nordigen.com` to `cdn-logos.gocardless.com`, as nordigen.com domain will be deprecated.
