### PR TITLE
fix: use correct path for type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     ".": {
       "require": "./dist/index.cjs",
       "import": "./dist/index.esm.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/types/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
## Related Issue

When importing `nordigen-node` in a project that uses ES modules, this TypeScript error pops up:

```
Could not find a declaration file for module 'nordigen-node'. './node_modules/.pnpm/nordigen-node@1.4.0/node_modules/nordigen-node/dist/index.esm.js' implicitly has an 'any' type.
  There are types at './node_modules/nordigen-node/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'nordigen-node' library may need to update its package.json or typings.ts(7016)
```

It happens because `exports.".".types` key points to a non-existent file `./dist/index.d.ts`, the real types are in fact located at `./dist/types/index.d.ts`.

## Proposed Changes
  * Make exported types for ES modules point to the same file as types for CommonJS modules.
