### PR TITLE
fix: Ensure types allow optional function arguments to be omitted

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ export default class NordigenClient {
     constructor({ secretId, secretKey, baseUrl, }: {
         secretId: string;
         secretKey: string;
-        baseUrl: string;
+        baseUrl?: string;
     });
     baseUrl: string;
     secretKey: string;
@@ -87,13 +87,13 @@ export default class NordigenClient {
     initSession({ redirectUrl, institutionId, maxHistoricalDays, accessValidForDays, userLanguage, referenceId, ssn, redirectImmediate, accountSelection, }: {
         redirectUrl: string;
         institutionId: string;
-        referenceId: string;
-        maxHistoricalDays: number;
-        accessValidForDays: number;
-        userLanguage: string;
-        ssn: string;
-        redirectImmediate: boolean;
-        accountSelection: boolean;
+        referenceId?: string;
+        maxHistoricalDays?: number;
+        accessValidForDays?: number;
+        userLanguage?: string;
+        ssn?: string;
+        redirectImmediate?: boolean;
+        accountSelection?: boolean;
     }): Promise<any>;
     #private;
 }


### PR DESCRIPTION
## Related Issue
The current type definitions do not distinguish between optional and required function arguments.

Therefore, the standard `NordigenClient` instantiation in Typescript results in a type error:
```
const client = new NordigenClient({
  secretId: process.env.SECRET_ID,
  secretKey: process.env.SECRET_KEY,
});
```

```
$ npm exec tsc
src/example.ts:1:35 - error TS2345: Argument of type '{ secretId: string; secretKey: string; }' is not assignable to parameter of type '{ secretId: string; secretKey: string; baseUrl: string; }'.
  Property 'baseUrl' is missing in type '{ secretId: string; secretKey: string; }' but required in type '{ secretId: string; secretKey: string; baseUrl: string; }'.
```

## Proposed Changes
  * Update type definitions for `NordigenClient` `constructor()` and `initSession()` to recognise optional arguments.

## Additional Info
n/a
